### PR TITLE
Add Netlify frontend URL to CORS whitelist

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -27,7 +27,10 @@ const connection = async () =>{
 }
 
 //CORS Configuration (react app allowed)
-const whitelist = ["http://localhost:3000"]
+const whitelist = [
+  "http://localhost:3000",
+  "https://freshorderapp.netlify.app/"
+]
 const corsOptions = {
   origin: function (origin, callback) {
     if (!origin || whitelist.indexOf(origin) !== -1) {


### PR DESCRIPTION
### Description
- Added the Netlify frontend URL to the CORS whitelist to allow API requests from the deployed app.