### PR TITLE
Rremove trailing slash from Netlify URL in whitelist

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -29,7 +29,7 @@ const connection = async () =>{
 //CORS Configuration (react app allowed)
 const whitelist = [
   "http://localhost:3000",
-  "https://freshorderapp.netlify.app/"
+  "https://freshorderapp.netlify.app"
 ]
 const corsOptions = {
   origin: function (origin, callback) {


### PR DESCRIPTION
### Description
Trailing slash removed from the Netlify URL in the whitelist. The trailing slash caused CORS requests from the deployed frontend to fail.